### PR TITLE
Fix llama-cpp build

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -141,7 +141,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       (cmakeBool "GGML_BLAS" blasSupport)
       (cmakeBool "GGML_CLBLAST" openclSupport)
       (cmakeBool "GGML_CUDA" cudaSupport)
-      (cmakeBool "GGML_HIPBLAS" rocmSupport)
+      (cmakeBool "GGML_HIP" rocmSupport)
       (cmakeBool "GGML_METAL" metalSupport)
       (cmakeBool "GGML_RPC" rpcSupport)
       (cmakeBool "GGML_VULKAN" vulkanSupport)
@@ -149,16 +149,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ++ optionals cudaSupport [
       (cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
     ]
-    ++ optionals rocmSupport [
-      (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
-      (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
-
-      # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
-      # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
-      # and select the line that matches the current nixpkgs version of rocBLAS.
-      # Should likely use `rocmPackages.clr.gpuTargets`.
-      "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
-    ]
+    ++ optionals rocmSupport (with rocmPackages; [
+      (cmakeFeature "CMAKE_HIP_COMPILER" "${clr.hipClangPath}/clang++")
+      # TODO: this should become `clr.gpuTargets` in the future.
+      (cmakeFeature "CMAKE_HIP_ARCHITECTURES" rocblas.amdgpu_targets)
+    ])
     ++ optionals metalSupport [
       (cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1")
       (cmakeBool "LLAMA_METAL_EMBED_LIBRARY" true)

--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -33,13 +33,14 @@
 }:
 
 let
-  hipClangPath = rocm-merged-llvm;
+  hipClang = rocm-merged-llvm;
+  hipClangPath = "${hipClang}/bin";
   wrapperArgs = [
     "--prefix PATH : $out/bin"
     "--prefix LD_LIBRARY_PATH : ${rocm-runtime}"
     "--set HIP_PLATFORM amd"
     "--set HIP_PATH $out"
-    "--set HIP_CLANG_PATH ${hipClangPath}/bin"
+    "--set HIP_CLANG_PATH ${hipClangPath}"
     "--set DEVICE_LIB_PATH ${rocm-device-libs}/amdgcn/bitcode"
     "--set HSA_PATH ${rocm-runtime}"
     "--set ROCM_PATH $out"
@@ -84,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
     libX11
     khronos-ocl-icd-loader
-    hipClangPath
+    hipClang
     libffi
     zstd
     zlib
@@ -163,7 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "install(PROGRAMS \''${HIPCC_BIN_DIR}/hipconfig.bat DESTINATION bin)" ""
 
     substituteInPlace hipamd/src/hip_embed_pch.sh \
-      --replace "\''$LLVM_DIR/bin/clang" "${hipClangPath}/bin/clang"
+      --replace "\''$LLVM_DIR/bin/clang" "${hipClangPath}/clang"
 
     substituteInPlace opencl/khronos/icd/loader/icd_platform.h \
       --replace-fail '#define ICD_VENDOR_PATH "/etc/OpenCL/vendors/";' \
@@ -205,7 +206,7 @@ stdenv.mkDerivation (finalAttrs: {
     export HIP_PLATFORM=amd
     export HIP_DEVICE_LIB_PATH="${rocm-device-libs}/amdgcn/bitcode"
     export NIX_CC_USE_RESPONSE_FILE=0
-    export HIP_CLANG_PATH="${hipClangPath}/bin"
+    export HIP_CLANG_PATH="${hipClangPath}"
     export ROCM_LIBPATCH_VERSION="${ROCM_LIBPATCH_VERSION}"
     export HSA_PATH="${rocm-runtime}"' > $out/nix-support/setup-hook
 
@@ -220,7 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
     # add version info to output (downstream rocmPackages look for this)
     ln -s ${rocm-core}/.info/ $out/.info
 
-    ln -s ${hipClangPath} $out/llvm
+    ln -s ${hipClang} $out/llvm
   '';
 
   disallowedRequisites = [
@@ -257,6 +258,8 @@ stdenv.mkDerivation (finalAttrs: {
         "1101"
         "1102"
       ] (target: "gfx${target}");
+
+      hipClangPath = hipClangPath;
 
       updateScript = rocmUpdateScript {
         name = finalAttrs.pname;

--- a/pkgs/development/rocm-modules/6/hipblas/default.nix
+++ b/pkgs/development/rocm-modules/6/hipblas/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   rocmUpdateScript,
   cmake,
   rocm-cmake,
@@ -47,6 +48,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Rz1KAhBUbvErHTF2PM1AkVhqo4OHldfSNMSpp5Tx9yk=";
   };
 
+  patches = [
+    # https://github.com/ROCm/hipBLAS/pull/952
+    (fetchpatch {
+      name = "transitively-depend-hipblas-common.patch";
+      url = "https://github.com/ROCm/hipBLAS/commit/54220fdaebf0fb4fd0921ee9e418ace5b143ec8f.patch";
+      hash = "sha256-MFEhv8Bkrd2zD0FFIDg9oJzO7ztdyMAF+R9oYA0rmwQ=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace library/CMakeLists.txt \
       --replace-fail "find_package(Git REQUIRED)" ""
@@ -63,6 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
     '')
   ];
 
+  propagatedBuildInputs = [ hipblas-common ];
+
   buildInputs =
     [
       rocblas
@@ -70,7 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
       rocsparse
       rocsolver
       # hipblaslt
-      hipblas-common
     ]
     ++ lib.optionals buildTests [
       gtest

--- a/pkgs/development/rocm-modules/6/hipblaslt/default.nix
+++ b/pkgs/development/rocm-modules/6/hipblaslt/default.nix
@@ -110,6 +110,8 @@ stdenv.mkDerivation (
         --replace-fail "virtualenv_install(\''${Tensile_TEST_LOCAL_PATH})" "" \
         --replace-fail "virtualenv_install(\''${CMAKE_SOURCE_DIR}/tensilelite)" "" \
         --replace-fail 'find_package(Tensile 4.33.0 EXACT REQUIRED HIP LLVM OpenMP PATHS "''${INSTALLED_TENSILE_PATH}")' "find_package(Tensile)"
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'Tensile_CPU_THREADS ""' 'Tensile_CPU_THREADS "$ENV{NIX_BUILD_CORES}"'
       if [ -f library/src/amd_detail/rocblaslt/src/kernels/compile_code_object.sh ]; then
         substituteInPlace library/src/amd_detail/rocblaslt/src/kernels/compile_code_object.sh \
           --replace-fail '${"\${rocm_path}"}/bin/' ""

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -32,6 +32,9 @@
   # depends on some previous commits.
   tensileSepArch ? true,
   tensileLazyLib ? true,
+  # TODO: ideally this can be turned off depending on `gpuTargets` as hipBLASLt
+  # only supports a small number of targets.
+  withHipBlasLt ? true,
   # `gfx940`, `gfx941` are not present in this list because they are early
   # engineering samples, and all final MI300 hardware are `gfx942`:
   # https://github.com/NixOS/nixpkgs/pull/298388#issuecomment-2032791130
@@ -94,6 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
     [
       python3
       hipblas-common
+    ]
+    ++ lib.optionals withHipBlasLt [
       hipblaslt
     ]
     ++ lib.optionals buildTensile [
@@ -143,6 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "BUILD_WITH_TENSILE" buildTensile)
       (lib.cmakeBool "ROCM_SYMLINK_LIBS" false)
       (lib.cmakeFeature "ROCBLAS_TENSILE_LIBRARY_DIR" "lib/rocblas")
+      (lib.cmakeBool "BUILD_WITH_HIPBLASLT" withHipBlasLt)
       (lib.cmakeBool "BUILD_CLIENTS_TESTS" buildTests)
       (lib.cmakeBool "BUILD_CLIENTS_BENCHMARKS" buildBenchmarks)
       (lib.cmakeBool "BUILD_CLIENTS_SAMPLES" buildBenchmarks)


### PR DESCRIPTION
The commits' titles should be pretty explanatory on what they each do. A few notes:

- In 6cb1f973853bc09902e95d59e19f2167753078f1, the rationale for this change is that `HIP_CLANG_PATH` is also used in `hipcc` as an environment variable that points to the directory that `clang` is in, so usually `/opt/rocm/llvm/bin`. To avoid confusion, I think it would be better to not use `hipClangPath` for anything (other than the directory that `clang` resides in). To remedy this, the original `hipClangPath` (= rocm-merged-llvm) is renamed to `hipClang`.
- The first two commits (df26888648452ed3810a8e3383c278c70e207f8a and fec1004674d96ca13cefd3b0773051b79b9ecd5e) are not as important as the last three, so feel free to let me know if you just want a PR containing the `llama.cpp` fixes.
- If you decide to merge this, a rebase merge would probably be the most convenient. Then you can squash some of my commits into yours for brevity/conciseness.
- Feel free to (force) push on this branch directly.

Please feel free to let me know if there are any concerns. 